### PR TITLE
support docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.17-alpine as builder
+
+LABEL maintainer="smallqi1@163.com"
+WORKDIR /app
+ENV GOPROXY=https://goproxy.cn
+COPY . .
+RUN go build -o busuanzi main.go
+
+FROM alpine:3.16
+WORKDIR /app
+
+COPY --from=builder /app/busuanzi /app
+COPY --from=builder /app/config.yaml /app
+COPY --from=builder /app/dist /app/dist
+COPY --from=builder /app/ENTRYPOINT.sh /app
+
+EXPOSE 8080
+ENTRYPOINT [ "./ENTRYPOINT.sh", "/app/busuanzi"]

--- a/ENTRYPOINT.sh
+++ b/ENTRYPOINT.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+set -x
+
+# busuanzi js API address
+if [ -n "$API_SERVER" ];then
+  sed -i "s/http:\/\/127.0.0.1:8080\/api/$API_SERVER/g" dist/busuanzi.js
+fi
+
+# 监听地址
+if [ -n "$WEB_ADDR" ];then
+  sed -i "s/Address: 127.0.0.1:8080/Address: $WEB_ADDR/g" config.yaml
+else
+  sed -i "s/Address: 127.0.0.1:8080/Address: 0.0.0.0:8080/g" config.yaml
+fi
+
+# redis地址
+if [ -n "$REDIS_ADDR" ];then
+  sed -i "s/Address: 127.0.0.1:6379/Address: $REDIS_ADDR/g" config.yaml
+else
+  sed -i "s/Address: 127.0.0.1:6379/Address: redis:6379/g" config.yaml
+fi
+
+# redis 密码
+if [ -n "$REDIS_PWD" ];then
+  sed -i "s/Password:/Password: $REDIS_PWD/g" config.yaml
+fi 
+
+# 是否开启debug模式
+if [ -n "$DEBUG_ENABLE" ];then
+  sed -i "s/Debug: true/Debug: $DEBUG_ENABLE/g" config.yaml
+fi 
+
+# 是否开启日志
+if [ -n "$LOG_ENABLE" ];then
+  sed -i "s/Log: true/Log: $LOG_ENABLE/g" config.yaml
+fi 
+
+# 统计数据过期时间 单位秒, 请输入整数 (无任何访问, 超过这个时间后, 统计数据将被清空, 0为不过期)
+if [ -n "$EXPIRE_TIME" ];then
+  sed -i "s/Expire: 2592000/Expire: $EXPIRE_TIME/g" config.yaml
+fi
+
+exec "$@"

--- a/README.md
+++ b/README.md
@@ -10,3 +10,62 @@
 # 安装
 
 > 详见 [WIKI](https://github.com/soxft/busuanzi/wiki/Install)
+
+## Docker 部署
+
+部署 Redis
+
+```shell
+docker run --name redis -d redis:latest
+```
+
+部署 busuanzi
+
+```shell
+docker run -p 8080:8080 --link redis -d qlucky/busuanzi:latest
+```
+
+可选参数：
+
+| 环境变量     | 参数说明                                                     |
+| ------------ | ------------------------------------------------------------ |
+| API_SERVER   | busuanzi.js API地址，默认：http://127.0.0.1:8080/api，修改需要添加转符：https:\/\/busuanzi.xxx.com\/api |
+| WEB_ADDR     | 默认 0.0.0.0:8080                                            |
+| REDIS_ADDR   | redis 连接地址，默认 redis:6379                              |
+| REDIS_PWD    | redis 密码，默认为空                                         |
+| DEBUG_ENABLE | 是否开启debug模式，默认 true                                 |
+| LOG_ENABLE   | 是否开启日志，默认 true                                      |
+| EXPIRE_TIME  | 统计数据过期时间 单位秒, 请输入整数 (无任何访问, 超过这个时间后, 统计数据将被清空, 0为不过期)，默认 `2592000` |
+
+修改默认参数示例：
+
+```shell
+docker run \
+-e API_SERVER="https:\/\/busuanzi.xxx.com\/api" \
+-e REDIS_ADDR=192.168.6.6:6379 \
+-e REDIS_PWD=123456 \
+-e DEBUG_ENABLE=true \
+-e LOG_ENABLE=true \
+-e EXPIRE_TIME=0 \
+-p 8080:8080 \
+--link redis \
+-d qlucky/busuanzi:latest
+```
+
+挂载配置文件示例：
+
+```shell
+docker run \
+-v ~/config.yaml:/app/config.yaml \
+-p 8080:8080 \
+--link redis \
+-d qlucky/busuanzi:latest
+```
+
+## Docker 源码构建
+
+只需安装docker环境即可
+
+```shell
+docker build -t busuanzi .
+```


### PR DESCRIPTION
非常好的项目，最近我也在为我的博客弄阅读量这个功能，避免重复造轮子，偶然间看到了你的项目，非常好。
不足的是没有提供 Docker 部署。

昨天我看你也提供了docker部署，但docker的镜像非常大，可能是没用多阶段构建产生了很多依赖包导致的。

本次提交我提供了：
1. Dockerfile 构建可供其他同学自己构建镜像
2. 添加了启动脚本，再 docker run 时可以使用 -e 指定环境变量来修改 `config.yaml` 文件内容。(同时也可以通过 -v 挂载配置文件)
3. 修改了 docker 部署的 readme 部分
4. docker 镜像提供多架构，支持 amd64，arm64，让 Apple M1 的同学也可以在自己的 Mac 的 Docker Desktop 中运行，详情见[docker hub](https://hub.docker.com/r/qlucky/busuanzi/tags)