### PR TITLE
兼容原版busuanzi container

### DIFF
--- a/dist/busuanzi.js
+++ b/dist/busuanzi.js
@@ -1,7 +1,4 @@
 !function() {
-    document.getElementById("busuanzi_container_site_pv").style.display = "none"
-    document.getElementById("busuanzi_container_page_pv").style.display = "none"
-    document.getElementById("busuanzi_container_site_uv").style.display = "none"
     var t = ["site_pv", "site_uv", "page_pv", "page_uv"]
       , e = document.currentScript
       , a = e.hasAttribute("pjax")
@@ -25,6 +22,10 @@
                     ));
                     var n = e.getResponseHeader("Set-Bsz-Identity");
                     null != n && "" != n && localStorage.setItem(i, n)
+                    
+                    document.getElementById("busuanzi_container_site_pv").style.display = "inline"
+                    document.getElementById("busuanzi_container_page_pv").style.display = "inline"
+                    document.getElementById("busuanzi_container_site_uv").style.display = "inline"
                 }
             }
         }
@@ -44,7 +45,4 @@
         }
         ), !1)
     }
-    document.getElementById("busuanzi_container_site_pv").style.display = "inline"
-    document.getElementById("busuanzi_container_page_pv").style.display = "inline"
-    document.getElementById("busuanzi_container_site_uv").style.display = "inline"
 }();

--- a/dist/busuanzi.js
+++ b/dist/busuanzi.js
@@ -22,9 +22,15 @@
                     ));
                     var n = e.getResponseHeader("Set-Bsz-Identity");
                     null != n && "" != n && localStorage.setItem(i, n)
-                    document.getElementById("busuanzi_container_site_pv").style.display = "inline"
-                    document.getElementById("busuanzi_container_page_pv").style.display = "inline"
-                    document.getElementById("busuanzi_container_site_uv").style.display = "inline"
+                    if (document.getElementById("busuanzi_container_site_pv")!=null) {
+                        document.getElementById("busuanzi_container_site_pv").style.display = "inline"
+                    }
+                    if (document.getElementById("busuanzi_container_page_pv")!=null) {
+                        document.getElementById("busuanzi_container_page_pv").style.display = "inline"
+                    }
+                    if (document.getElementById("busuanzi_container_site_uv")!=null) {
+                        document.getElementById("busuanzi_container_site_uv").style.display = "inline"
+                    }
                 }
             }
         }

--- a/dist/busuanzi.js
+++ b/dist/busuanzi.js
@@ -22,7 +22,6 @@
                     ));
                     var n = e.getResponseHeader("Set-Bsz-Identity");
                     null != n && "" != n && localStorage.setItem(i, n)
-                    
                     document.getElementById("busuanzi_container_site_pv").style.display = "inline"
                     document.getElementById("busuanzi_container_page_pv").style.display = "inline"
                     document.getElementById("busuanzi_container_site_uv").style.display = "inline"

--- a/dist/busuanzi.js
+++ b/dist/busuanzi.js
@@ -1,1 +1,50 @@
-!function(){var t=["site_pv","site_uv","page_pv","page_uv"],e=document.currentScript,a=e.hasAttribute("pjax"),n=e.getAttribute("data-api")||"http://127.0.0.1:8080/api",r=e.getAttribute("data-prefix")||"busuanzi",i="bsz-id",s=function(){var e=new XMLHttpRequest;e.open("POST",n,!0);var a=localStorage.getItem(i);null!=a&&e.setRequestHeader("Authorization","Bearer "+a),e.setRequestHeader("x-bsz-referer",window.location.href),e.onreadystatechange=function(){if(4===e.readyState&&200===e.status){var a=JSON.parse(e.responseText);if(!0===a.success){t.map((function(t){var e=document.getElementById("".concat(r,"_").concat(t));e&&(e.innerHTML=a.data[t])}));var n=e.getResponseHeader("Set-Bsz-Identity");null!=n&&""!=n&&localStorage.setItem(i,n)}}},e.send()};if(s(),a){var o=window.history.pushState;window.history.pushState=function(){o.apply(this,arguments),s()},window.addEventListener("popstate",(function(t){s()}),!1)}}();
+!function() {
+    document.getElementById("busuanzi_container_site_pv").style.display = "none"
+    document.getElementById("busuanzi_container_page_pv").style.display = "none"
+    document.getElementById("busuanzi_container_site_uv").style.display = "none"
+    var t = ["site_pv", "site_uv", "page_pv", "page_uv"]
+      , e = document.currentScript
+      , a = e.hasAttribute("pjax")
+      , n = e.getAttribute("data-api") || "http://127.0.0.1:8080/api"
+      , r = e.getAttribute("data-prefix") || "busuanzi"
+      , i = "bsz-id"
+      , s = function() {
+        var e = new XMLHttpRequest;
+        e.open("POST", n, !0);
+        var a = localStorage.getItem(i);
+        null != a && e.setRequestHeader("Authorization", "Bearer " + a),
+        e.setRequestHeader("x-bsz-referer", window.location.href),
+        e.onreadystatechange = function() {
+            if (4 === e.readyState && 200 === e.status) {
+                var a = JSON.parse(e.responseText);
+                if (!0 === a.success) {
+                    t.map((function(t) {
+                        var e = document.getElementById("".concat(r, "_").concat(t));
+                        e && (e.innerHTML = a.data[t])
+                    }
+                    ));
+                    var n = e.getResponseHeader("Set-Bsz-Identity");
+                    null != n && "" != n && localStorage.setItem(i, n)
+                }
+            }
+        }
+        ,
+        e.send()
+    };
+    if (s(),
+    a) {
+        var o = window.history.pushState;
+        window.history.pushState = function() {
+            o.apply(this, arguments),
+            s()
+        }
+        ,
+        window.addEventListener("popstate", (function(t) {
+            s()
+        }
+        ), !1)
+    }
+    document.getElementById("busuanzi_container_site_pv").style.display = "inline"
+    document.getElementById("busuanzi_container_page_pv").style.display = "inline"
+    document.getElementById("busuanzi_container_site_uv").style.display = "inline"
+}();


### PR DESCRIPTION
busuanzi原版可以使用busuanzi_container id，其中包含文字例如(<span id="busuanzi_container_site_pv">总访问量 <span id="busuanzi_value_site_pv">311</span> 次 </span>)，这样在加载的时候，整段文字一开始会隐藏，等到加载完毕会整体一起显示，不会出现有文字但是没有数字的情况